### PR TITLE
Implement update updateHistory to save histories entries 

### DIFF
--- a/src/api/fetchAPIBackend.ts
+++ b/src/api/fetchAPIBackend.ts
@@ -1,0 +1,41 @@
+import { HistorySaveResponse } from '../interfaces/history.interface';
+
+export interface HistoryToSave {
+  place: string;
+  city: string;
+  country: string;
+  coordinates: {
+    longitude: number;
+    latitude: number;
+  };
+}
+
+export const fetchAPIBackend = async (history: HistoryToSave): Promise<HistorySaveResponse> => {
+  console.log({ history });
+  const baseUrl = import.meta.env.VITE_BACKEND_URL;
+
+  try {
+    const options = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': `${import.meta.env.VITE_API_KEY_BACK}`,
+      },
+      body: JSON.stringify(history),
+    };
+    const response = await fetch(`${baseUrl}/addresses`, options);
+
+    if (!response.ok) {
+      throw new Error('Error fetching data from the API');
+    }
+    const data = (await response.json()) as HistorySaveResponse;
+    return data;
+  } catch (error) {
+    //TODO: Handle error in a custom error handler
+    if (error instanceof Error) {
+      throw new Error('Error fetching data from the API ' + error.message);
+    } else {
+      throw new Error('Error fetching data from the API');
+    }
+  }
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,2 +1,4 @@
 export * from './directionsApi';
 export * from './searchApi';
+
+export * from './fetchAPIBackend';

--- a/src/components/gps/search-results/SearchResults.tsx
+++ b/src/components/gps/search-results/SearchResults.tsx
@@ -1,12 +1,15 @@
 import { Marker } from 'mapbox-gl';
 import { useState } from 'react';
 import { useMap, usePlaces } from '../../../hook';
+import { useHistory } from '../../../hook/useHistory';
+import { IntSearch } from '../../../interfaces/history.interface';
 import { Feature } from '../../../interfaces/PlacesResponce.interface';
 import { SearchResultsSkeleton } from '../../ui/search-results-skleton/SearchResultsSkeleton';
 import './searchResults.scss';
 export const SearchResults = () => {
   const { places, isLoadingPlaces, userLocation } = usePlaces();
   const { map, getRouteBetweenPoints } = useMap();
+  const { updateHistory } = useHistory();
   const [activeMarker, setActiveMarker] = useState<Marker | null>(null);
   const [activeId, setActiveId] = useState<string>('');
 
@@ -29,6 +32,19 @@ export const SearchResults = () => {
     if (!userLocation) return;
     const [lng, lat] = place.geometry.coordinates;
     getRouteBetweenPoints(userLocation, [lng, lat]);
+
+    //Save the place in the history
+    const historyToSave: IntSearch = {
+      type: 'addresses',
+      id: parseInt(place.id),
+      attributes: {
+        place: place.properties.name_preferred,
+        city: place.properties.full_address,
+        country: place.properties.context.country.name,
+        coordinates: [lng, lat],
+      },
+    };
+    updateHistory(historyToSave);
   };
 
   if (!places.length) return <></>;
@@ -50,7 +66,7 @@ export const SearchResults = () => {
               <button className="search-results__button" onClick={() => getRoute(place)}>
                 Directions
               </button>
-              <img src='images/bauble.png' className='search-results__bauble'/>
+              <img src="images/bauble.png" className="search-results__bauble" />
             </li>
           ))}
         </ul>

--- a/src/context/history/HistoryProvider.tsx
+++ b/src/context/history/HistoryProvider.tsx
@@ -1,5 +1,7 @@
 import { useReducer } from 'react';
+import { fetchAPIBackend, HistoryToSave } from '../../api';
 import { IntSearch } from '../../interfaces/history.interface';
+import { isInHistory } from '../../utils';
 import { HistoryContext } from './HistoryContext';
 import { historyReducer } from './historyReducer';
 
@@ -24,7 +26,24 @@ export const HistoryProvider = ({ children }: Props) => {
     dispatch({ type: 'SET_HISTORY', payload: history });
   };
 
-  const updateHistory = (history: IntSearch) => {};
+  const updateHistory = async (history: IntSearch) => {
+    if (isInHistory(state.history, history)) return;
+
+    const historyToSave: HistoryToSave = {
+      place: history.attributes.place,
+      city: history.attributes.city,
+      country: history.attributes.country,
+      coordinates: {
+        longitude: history.attributes.coordinates[0],
+        latitude: history.attributes.coordinates[1],
+      },
+    };
+
+    const response = await fetchAPIBackend(historyToSave);
+    if (!response.message) return;
+
+    dispatch({ type: 'UPDATE_HISTORY', payload: history });
+  };
 
   return (
     <HistoryContext.Provider value={{ ...state, setHistory, updateHistory }}>

--- a/src/context/history/historyReducer.ts
+++ b/src/context/history/historyReducer.ts
@@ -13,6 +13,11 @@ export const historyReducer = (state: HistoryState, action: HistoryAction): Hist
         isLoading: false,
         history: action.payload,
       };
+    case 'UPDATE_HISTORY':
+      return {
+        ...state,
+        history: [action.payload, ...state.history],
+      };
 
     default:
       return state;

--- a/src/interfaces/history.interface.ts
+++ b/src/interfaces/history.interface.ts
@@ -10,3 +10,17 @@ export interface IntSearch {
   id: number;
   attributes: IntAttributtes;
 }
+
+export interface HistorySaveResponse {
+  message: string;
+  address: {
+    place: string;
+    city: string;
+    country: string;
+    longitude: number;
+    latitude: number;
+    updated_at: string;
+    created_at: string;
+    id: number;
+  };
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,5 @@ export * from './getUserLocation';
 export * from './grinchMarker';
 
 export * from './addRouteToMap';
+
+export * from './isInHistory';

--- a/src/utils/isInHistory.ts
+++ b/src/utils/isInHistory.ts
@@ -1,0 +1,8 @@
+import { IntSearch } from '../interfaces/history.interface';
+
+export const isInHistory = (history: IntSearch[], historyToSave: IntSearch): boolean => {
+  const existInHistory = history.some(
+    (historyItem) => historyItem.attributes.place === historyToSave.attributes.place,
+  );
+  return existInHistory;
+};


### PR DESCRIPTION
- Implement updateHistory to save history entries.
- Check if the history exists in the history state.
- Send the new history to the back-end and update the history state.