### PR TITLE
fix: styles history container

### DIFF
--- a/src/components/history/History.scss
+++ b/src/components/history/History.scss
@@ -18,11 +18,11 @@
 
   &__container {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
     gap: 1rem;
 
     @media screen and (max-width: 48rem) {
-      grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
     }
   }
 


### PR DESCRIPTION
The container of results when only have one result fill all the space available, that isn't correct change the responsive container to use auto-fill instead auto-fit