### PR TITLE
fix: add border-radius map preview

### DIFF
--- a/src/components/gps/map-preview/MapPreview.scss
+++ b/src/components/gps/map-preview/MapPreview.scss
@@ -1,0 +1,4 @@
+.map {
+  border-radius: 0.3125rem;
+  border: 0.125rem solid var(--border-color);
+}

--- a/src/components/gps/map-preview/MapPreview.tsx
+++ b/src/components/gps/map-preview/MapPreview.tsx
@@ -3,6 +3,7 @@ import { useLayoutEffect, useRef } from 'react';
 import { useMap } from '../../../hook/useMap';
 import { usePlaces } from '../../../hook/usePlaces';
 import { MapSkeleton } from '../../ui/map-skeleton/MapSkeleton';
+import './MapPreview.scss'
 
 export const MapPreview = () => {
   const { isLoading, userLocation } = usePlaces();

--- a/src/pages/gps/gps.scss
+++ b/src/pages/gps/gps.scss
@@ -22,7 +22,6 @@
     position: relative;
     min-height: 70vh;
     margin-bottom: 1rem;
-    border: 0.125rem solid var(--border-color);
   }
 }
 


### PR DESCRIPTION
Add a border-radius of map preview to match with the rest of the project.