### PR TITLE
fix: favicon link console error message

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/public/images/gift.svg" />
+    <link rel="icon" type="image/svg+xml" href="/images/gift.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="https://api.mapbox.com/mapbox-gl-js/v3.7.0/mapbox-gl.css" rel="stylesheet" />
     <title>Christmas tools</title>


### PR DESCRIPTION
## Description
Fix the error message in the console about the favicon.

## Trello
https://trello.com/c/T8e2Eklu

## Screenshoot
![image](https://github.com/user-attachments/assets/b2b032a8-f73f-460b-a62f-e62d2dba9c8d)
