### PR TITLE
fix: letter stamp position and text

### DIFF
--- a/src/components/letter-modal/LetterModal.scss
+++ b/src/components/letter-modal/LetterModal.scss
@@ -55,18 +55,18 @@
 
   &__stamp {
     position: absolute;
-    bottom: 10%;
+    bottom: 20%;
     left: 20%;
 
     border: solid 0.1rem var(--dark-red);
     border-radius: 0.1rem;
     color: var(--dark-red);
-    font-size: .5rem;
+    font-size: 0.5rem;
     font-weight: bold;
     line-height: 1;
     padding: 0.1rem 0.5rem;
     transform-origin: 50% 50%;
-    transform: rotate(-12deg) scale(5);
+    transform: rotate(-20deg) scale(5);
     transition: all 0.3s cubic-bezier(0.6, 0.04, 0.98, 0.335);
   }
 

--- a/src/components/letter-modal/LetterModal.tsx
+++ b/src/components/letter-modal/LetterModal.tsx
@@ -41,7 +41,7 @@ const LetterModal = ({ letter: { content, date, image, read, sender, subject } }
           <IoClose />
         </button>
 
-        {read && <div className="letter__stamp">READ IT</div>}
+        {read && <div className="letter__stamp">READ</div>}
       </dialog>
     </>
   );


### PR DESCRIPTION
## Description
Modifiy the position of the stamp to resolve the scroll-bar and the text inside the stamp for READ only.

## Trello
https://trello.com/c/ZhUOQl8b

##Screenshoots
![image](https://github.com/user-attachments/assets/9f097198-3b7b-4ac1-b114-511c2dc52274)
![image](https://github.com/user-attachments/assets/580487b1-5fed-4176-8355-2dc6b6b1073a)
