### PR TITLE
Bugfix: Close GPS Dropdown on user interaction

### DIFF
--- a/src/components/gps/search-results/SearchResults.tsx
+++ b/src/components/gps/search-results/SearchResults.tsx
@@ -1,5 +1,5 @@
 import { Marker } from 'mapbox-gl';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMap, usePlaces } from '../../../hook';
 import { useHistory } from '../../../hook/useHistory';
 import { IntSearch } from '../../../interfaces/history.interface';
@@ -46,6 +46,22 @@ export const SearchResults = () => {
     };
     updateHistory(historyToSave);
   };
+
+  // Remove suggestions when user selects a route
+  useEffect(() => {
+    const dropdownItems = document.querySelectorAll('.search-results__button');
+    
+    const handleSelection = () => {
+      const dropdown: HTMLInputElement | null = document.querySelector('.search-results');
+      if (dropdown) dropdown.style.display = 'none'
+    };
+  
+    dropdownItems.forEach(item => item.addEventListener('click', handleSelection));
+  
+    return () => {
+      dropdownItems.forEach(item => item.removeEventListener('click', handleSelection));
+    };
+  }, [places]);
 
   if (!places.length) return <></>;
 

--- a/src/components/gps/search-results/SearchResults.tsx
+++ b/src/components/gps/search-results/SearchResults.tsx
@@ -50,16 +50,24 @@ export const SearchResults = () => {
   // Remove suggestions when user selects a route
   useEffect(() => {
     const dropdownItems = document.querySelectorAll('.search-results__button');
+    const dropdown: HTMLInputElement | null = document.querySelector('.search-results');
     
     const handleSelection = () => {
-      const dropdown: HTMLInputElement | null = document.querySelector('.search-results');
       if (dropdown) dropdown.style.display = 'none'
+    };
+
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (dropdown && !dropdown.contains(event.target as Node)) {
+        dropdown.style.display = 'none';
+      }
     };
   
     dropdownItems.forEach(item => item.addEventListener('click', handleSelection));
+    document.addEventListener('mousedown', handleOutsideClick);
   
     return () => {
       dropdownItems.forEach(item => item.removeEventListener('click', handleSelection));
+      document.removeEventListener('mousedown', handleOutsideClick);
     };
   }, [places]);
 


### PR DESCRIPTION
The suggestions list is now removed from the screen when the user either:

- Generates a route by clicking the "Directions" button.
- Clicks outside of the suggestions element.

### Trello:

https://trello.com/c/uqBXwlec/53-bugfix-close-the-dropdown-of-search-bar-after-click-a-route-or-direction