### PR TITLE
fix: fix GPS title responsive

### DIFF
--- a/src/pages/gps/gps.scss
+++ b/src/pages/gps/gps.scss
@@ -4,14 +4,13 @@
     gap: 1rem;
   }
   &__title {
-    font-family: 'Geist', sans-serif;
     text-transform: uppercase;
     font-weight: 900;
-    letter-spacing: 1rem;
-    font-size: 3rem;
+    letter-spacing: clamp(0.5rem, 1.5vw, 1rem);
+    font-size: clamp(1.3rem, 3.2vw, 3rem);
     margin-bottom: 0.5rem;
     color: var(--light-red);
-    -webkit-text-stroke: 3px var(--light-red);
+    -webkit-text-stroke: clamp(0.1075rem, 0.6vw, 0.1875rem) var(--light-red);
   }
   &__subtitle {
     display: inline-block;

--- a/src/styles/reset/_reset.scss
+++ b/src/styles/reset/_reset.scss
@@ -30,13 +30,6 @@
 
   /* Tipografía */
   --primary-font: 'Geist', Helvetica, Arial, sans-serif;
-
-  @font-face {
-    font-family: 'Great Vibes';
-    src: url('/fonts/GreatVibes-Regular.ttf') format('truetype');
-    font-weight: normal;
-    font-style: normal;
-  }
 }
 
 *,


### PR DESCRIPTION
- Improve GPS title responsive.
- Remove Font-family Great Vibes from root.
Trello: https://trello.com/c/Hq4igxtz/69-fix-gps-title-responsive
![image](https://github.com/user-attachments/assets/52f7e760-e69e-4cdf-a847-0bfc04857378)
